### PR TITLE
Some fixes

### DIFF
--- a/HPSU/HPSU.py
+++ b/HPSU/HPSU.py
@@ -98,7 +98,7 @@ class HPSU(object):
             elif level == 'exception':
                 self.logger.exception(msg)
         else:
-            if self.driver == "HPSUD":
+            if self.driver != "HPSUD":
                 print("%s - %s" % (level, msg))
     
     def sendCommandWithParse(self, cmd, setValue=None, priority=1):

--- a/HPSU/HPSU.py
+++ b/HPSU/HPSU.py
@@ -98,7 +98,8 @@ class HPSU(object):
             elif level == 'exception':
                 self.logger.exception(msg)
         else:
-            print("%s - %s" % (level, msg))
+            if self.driver == "HPSUD":
+                print("%s - %s" % (level, msg))
     
     def sendCommandWithParse(self, cmd, setValue=None, priority=1):
         response = None

--- a/HPSU/canelm327.py
+++ b/HPSU/canelm327.py
@@ -11,7 +11,7 @@ class CanELM327(object):
     hpsu = None
     def __init__(self, hpsu=None):
         self.hpsu = hpsu
-    
+
     def resetInterface(self):
         self.ser.flushInput()  #flush input buffer, discarding all its contents
         self.ser.flushOutput() #flush output buffer, aborting current output and discard all that is in buffer
@@ -20,7 +20,7 @@ class CanELM327(object):
         except:
             pass
         self.initInterface(self.portstr, 38400, True)
-    
+
     def initInterface(self, portstr=None, baudrate=38400, init=False):
         self.portstr = portstr
         try:
@@ -49,8 +49,7 @@ class CanELM327(object):
                     self.hpsu.printd("error", "Error sending AT PP 2F ON (rc:%s)" % rc)
                     count_1+=1
                     time.sleep(1)
-                
-            
+
             """rc = self.sendCommand("AT D")
             if rc != "OK":
                 print "Error sending AT D (rc:%s)" % rc
@@ -81,7 +80,7 @@ class CanELM327(object):
                 command = command+" %02X 00" % (setValue)
             if type == "longint":
                 setValue = int(setValue)
-                command = command+"00 %02X" % (setValue)
+                command = command+" 00 %02X" % (setValue)
             if type == "float":
                 setValue = int(setValue)
                 if setValue < 0:
@@ -110,7 +109,6 @@ class CanELM327(object):
         else:
             rc = self.sendCommand("ATSH"+cmd["id"])
         if rc != "OK":
-            #self.eprint("Error setting ID %s (rc:%s)" % (cmd["receiver_id"], rc))
             self.resetInterface()
             self.hpsu.printd('warning', "Error setting ID %s (rc:%s)" % (cmd["id"], rc))
             return "KO"
@@ -120,7 +118,6 @@ class CanELM327(object):
             return rc
 
         if rc[0:1] != cmd["command"][0:1]:
-            #self.eprint("Error sending cmd %s (rc:%s)" % (cmd["command"], rc))
             self.resetInterface()
             self.hpsu.printd('warning', 'sending cmd %s (rc:%s)' % (cmd["command"], rc))
             return "KO"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The advantage of SocketCan: it can handle multiple instances or programs talking
 
 # Hardware setup
 1. Via Elm327 interface
-- Most cheap china replicas will not work because the "AT PP" command is not implemented. A purchase recommendation is as follows: https://www.totalcardiagnostics.com/elm327
+- Most cheap china replicas will not work because the "AT PP" command is not implemented. A purchase recommendation is as follows: https://www.totalcardiagnostics.com/elm327 or ahermann86 is using https://www.amazon.de/dp/B06XJ6GQZX/ref=cm_sw_em_r_mt_dp_U_OLP.CbG0Z7YKR
 - It is recommended to order a matching obd2 socket (16pol) to connect the can adapter
 - Connect the CAN-High cable pin 6, the CAN-Low cable pin 14 and CAN signal ground pin 5 to the hpsu mainboards "J13" connector. (Power on the CAN-Side is not needed)
 - look at your systems "dmesg" while  connecting to get the device name 

--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -219,17 +219,16 @@
 			"divisor" : "1", 
 			"writable" : "true", 
 			"unit" : "",
-			"type" : "int"
+			"type" : "int",
 			"value_code" : {
 				"1" : "standby",
 				"3" : "heat",
 				"4" : "sink", 
 				"5" : "summer",
-				"17" : "cool"
-				"11" : "auto 1"
+				"17" : "cool",
+				"11" : "auto 1",
 				"12" : "auto 2"
 			}
-			
 		},
 		"tvbh2" : { 
 			"name" : "tvbh2", 

--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -220,6 +220,16 @@
 			"writable" : "true", 
 			"unit" : "",
 			"type" : "int"
+			"value_code" : {
+				"1" : "standby",
+				"3" : "heat",
+				"4" : "sink", 
+				"5" : "summer",
+				"17" : "cool"
+				"11" : "auto 1"
+				"12" : "auto 2"
+			}
+			
 		},
 		"tvbh2" : { 
 			"name" : "tvbh2", 

--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -219,7 +219,7 @@
 			"divisor" : "1", 
 			"writable" : "true", 
 			"unit" : "",
-			"type" : "value"
+			"type" : "int"
 		},
 		"tvbh2" : { 
 			"name" : "tvbh2", 

--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -215,7 +215,6 @@ def main(argv):
                 print("Error, please specify a value to query in config file ")
                 sys.exit(9)
 
-
     #
     # Print help
     #
@@ -282,7 +281,6 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
     #    print("Error, please specify driver [ELM327 or PYCAN, EMU, HPSUD]")
     #    sys.exit(9)
 
-
     arrResponse = []
 
     for c in n_hpsu.commands:
@@ -292,6 +290,9 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
                     setValue = i.split(":")[1]
                     if not c["type"] == "value":
                         setValue = float(setValue)*float(c["divisor"])
+                    else:
+                        n_hpsu.printd('error', 'type value not implemented' % (c["name"]))
+                        return
 
             i = 0
             while i <= 3:
@@ -324,16 +325,11 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
         except FileNotFoundError:
             print("No such file or directory!!!")
             sys.exit(1)
-
-
     else:
         module_name=output_type.lower()
         module = importlib.import_module("HPSU.plugins." + module_name)
         hpsu_plugin = module.export(hpsu=n_hpsu, logger=logger, config_file=conf_file)
         hpsu_plugin.pushValues(vars=arrResponse)
-
-
-
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -291,7 +291,7 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
                     if not c["type"] == "value":
                         setValue = float(setValue)*float(c["divisor"])
                     else:
-                        n_hpsu.printd('error', 'type value not implemented' % (c["name"]))
+                        n_hpsu.printd('error', 'type "value" not implemented since yet')
                         return
 
             i = 0


### PR DESCRIPTION
- commands_hpsu.json: "mode_01" type and values
- pyHPSU.py: command "value" isn't implemented since yet. If this command is set, pyHPSU will terminate and will not send undefined command to Rotex RoCon.
- HPSU.py: No log if no logfile is set and HPSUD is active. It causes lots of warnings in FHEM...
- README.md: buy recommendation added