### PR TITLE
Logrevision

### DIFF
--- a/HPSU/HPSU.py
+++ b/HPSU/HPSU.py
@@ -45,12 +45,13 @@ class HPSU(object):
             hpsuDict = {}
             
             # read the translation file. if it doesn't exist, take the english one
-            commands_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, LANG_CODE)
-            if not os.path.isfile(commands_hpsu):
-                commands_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, "EN")
+            command_translations_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, LANG_CODE)
+            if not os.path.isfile(command_translations_hpsu):
+                command_translations_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, "EN")
+            self.printd("info", "loading command traslations file: "+command_translations_hpsu)
             # check, if commands are json or csv
             # read all known commands
-            with open(commands_hpsu, 'rU',encoding='utf-8') as csvfile:
+            with open(command_translations_hpsu, 'rU',encoding='utf-8') as csvfile:
                 pyHPSUCSV = csv.reader(csvfile, delimiter=';', quotechar='"')
                 next(pyHPSUCSV, None) # skip the header
                 for row in pyHPSUCSV:
@@ -60,8 +61,9 @@ class HPSU(object):
                     hpsuDict.update({name:{"label":label, "desc":desc}})
 
             # read all known commands
-
-            with open('%s/commands_hpsu.json' % self.pathCOMMANDS, 'rU',encoding='utf-8') as jsonfile:
+            command_details_hpsu = '%s/commands_hpsu.json' % self.pathCOMMANDS
+            self.printd("info", "loading command details file: "+command_details_hpsu)
+            with open(command_details_hpsu, 'rU',encoding='utf-8') as jsonfile:
                 self.all_commands = json.load(jsonfile)
                 self.command_dict=self.all_commands["commands"]
                 for single_command in self.command_dict:
@@ -89,14 +91,16 @@ class HPSU(object):
 
     def printd(self, level, msg):        
         if self.logger:
+            if level == 'debug':
+                self.logger.debug(msg)
+            elif level == 'info':
+                self.logger.info(msg)
             if level == 'warning':
                 self.logger.warning(msg)
             elif level == 'error':
                 self.logger.error(msg)
-            elif level == 'info':
-                self.logger.info(msg)
-            elif level == 'exception':
-                self.logger.exception(msg)
+            elif level == 'critical':
+                self.logger.critical(msg)
         else:
             if self.driver != "HPSUD":
                 print("%s - %s" % (level, msg))

--- a/HPSU/HPSU.py
+++ b/HPSU/HPSU.py
@@ -14,6 +14,7 @@ import csv
 import json
 import os.path
 import time
+import logging
 
 class HPSU(object):
     commands = []
@@ -48,7 +49,7 @@ class HPSU(object):
             command_translations_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, LANG_CODE)
             if not os.path.isfile(command_translations_hpsu):
                 command_translations_hpsu = '%s/commands_hpsu_%s.csv' % (self.pathCOMMANDS, "EN")
-            self.printd("info", "loading command traslations file: "+command_translations_hpsu)
+            self.logger.info("loading command traslations file: "+command_translations_hpsu)
             # check, if commands are json or csv
             # read all known commands
             with open(command_translations_hpsu, 'rU',encoding='utf-8') as csvfile:
@@ -62,7 +63,7 @@ class HPSU(object):
 
             # read all known commands
             command_details_hpsu = '%s/commands_hpsu.json' % self.pathCOMMANDS
-            self.printd("info", "loading command details file: "+command_details_hpsu)
+            self.logger.info("loading command details file: "+command_details_hpsu)
             with open(command_details_hpsu, 'rU',encoding='utf-8') as jsonfile:
                 self.all_commands = json.load(jsonfile)
                 self.command_dict=self.all_commands["commands"]
@@ -84,26 +85,10 @@ class HPSU(object):
         elif self.driver == "HPSUD":
             self.can = CanTCP(self)
         else:
-            print("Error selecting driver %s" % self.driver)
+            logger.error("Error selecting driver %s" % self.driver)
             sys.exit(9)
 
         self.initInterface(port)
-
-    def printd(self, level, msg):        
-        if self.logger:
-            if level == 'debug':
-                self.logger.debug(msg)
-            elif level == 'info':
-                self.logger.info(msg)
-            if level == 'warning':
-                self.logger.warning(msg)
-            elif level == 'error':
-                self.logger.error(msg)
-            elif level == 'critical':
-                self.logger.critical(msg)
-        else:
-            if self.driver != "HPSUD":
-                print("%s - %s" % (level, msg))
     
     def sendCommandWithParse(self, cmd, setValue=None, priority=1):
         response = None

--- a/HPSU/canelm327.py
+++ b/HPSU/canelm327.py
@@ -30,7 +30,7 @@ class CanELM327(object):
             self.ser.flushInput()  #flush input buffer, discarding all its contents
             self.ser.flushOutput() #flush output buffer, aborting current output and discard all that is in buffer
         except serial.SerialException:
-            self.hpsu.printd("error", "Error opening serial %s" % portstr)
+            self.hpsu.logger.error("Error opening serial %s" % portstr)
             sys.exit(9)
 
         if init:
@@ -38,31 +38,31 @@ class CanELM327(object):
                         
             rc = self.sendCommand("AT PP 2F ON")
             """ if rc != "OK":
-                self.hpsu.printd("error", "Error sending AT PP 2F ON (rc:%s)" % rc)
+                self.hpsu.logger.error("Error sending AT PP 2F ON (rc:%s)" % rc)
                 sys.exit(9) """
             count_1=0
             while rc != "OK":
                 if count_1==15:
-                    self.hpsu.printd("error", "can adapter not responding: (rc:%s)" % rc)
+                    self.hpsu.logger.error("can adapter not responding: (rc:%s)" % rc)
                     sys.exit(9)
                 else:
-                    self.hpsu.printd("error", "Error sending AT PP 2F ON (rc:%s)" % rc)
+                    self.hpsu.logger.error("Error sending AT PP 2F ON (rc:%s)" % rc)
                     count_1+=1
                     time.sleep(1)
 
             """rc = self.sendCommand("AT D")
             if rc != "OK":
-                print "Error sending AT D (rc:%s)" % rc
+                self.hpsu.logger.error("Error sending AT D (rc:%s)" % rc)
                 sys.exit(9)"""
             
             rc = self.sendCommand("AT SP C")
             count_2=0
             while rc != "OK":
                 if count_2==15:
-                    self.hpsu.printd("error", "can adapter not responding: (rc:%s)" % rc)
+                    self.hpsu.logger.error("can adapter not responding: (rc:%s)" % rc)
                     sys.exit(9)
                 else:  
-                    self.hpsu.printd("error", "Error sending AT SP C (rc:%s)" % rc)
+                    self.hpsu.logger.error("Error sending AT SP C (rc:%s)" % rc)
                     count_2+=1
                     time.sleep(1)
 
@@ -90,7 +90,7 @@ class CanELM327(object):
                 setValue = int(setValue)
                 command = command+" 00 %02X" % (setValue)
 
-            #self.hpsu.printd("info", "cmd: %s cmdMod: %s" % (cmd, command))
+            #self.hpsu.logger.info("cmd: %s cmdMod: %s" % (cmd, command))
             cmd = command
 
         self.ser.write(bytes(str("%s\r\n" % cmd).encode('utf-8')))
@@ -110,7 +110,7 @@ class CanELM327(object):
             rc = self.sendCommand("ATSH"+cmd["id"])
         if rc != "OK":
             self.resetInterface()
-            self.hpsu.printd('warning', "Error setting ID %s (rc:%s)" % (cmd["id"], rc))
+            self.hpsu.logger.warning("Error setting ID %s (rc:%s)" % (cmd["id"], rc))
             return "KO"
         
         rc = self.sendCommand(cmd["command"], setValue, cmd["type"])
@@ -119,7 +119,7 @@ class CanELM327(object):
 
         if rc[0:1] != cmd["command"][0:1]:
             self.resetInterface()
-            self.hpsu.printd('warning', 'sending cmd %s (rc:%s)' % (cmd["command"], rc))
+            self.hpsu.logger.warning('sending cmd %s (rc:%s)' % (cmd["command"], rc))
             return "KO"
         
         return rc

--- a/HPSU/canemu.py
+++ b/HPSU/canemu.py
@@ -56,7 +56,7 @@ class CanEMU(object):
 
         if cmd["name"] == "runtime_pump":
             #self.eprint("Error sending %s" % (cmd["name"]))
-            self.hpsu.printd('warning', 'sending cmd %s (rc:%s)' % (cmd["name"], "ko"))
+            self.hpsu.logger.warning('sending cmd %s (rc:%s)' % (cmd["name"], "ko"))
             return "KO"
         
         #time.sleep(2.0)

--- a/HPSU/canpi.py
+++ b/HPSU/canpi.py
@@ -21,7 +21,7 @@ class CanPI(object):
         try:
             self.bus = can.interface.Bus(channel='can0', bustype='socketcan_native')
         except Exception:
-            self.hpsu.printd('exception', 'Error opening bus can0')
+            self.hpsu.logger.exception('Error opening bus can0')
             sys.exit(9)
             
         config = configparser.ConfigParser()
@@ -45,7 +45,7 @@ class CanPI(object):
         """try:
             self.bus.shutdown()
         except Exception:
-            self.hpsu.printd('exception', 'Error shutdown canbus')"""
+            self.hpsu.logger.exception('Error shutdown canbus')"""
     
     def sendCommandWithID(self, cmd, setValue=None, priority=1):
         if setValue:
@@ -88,7 +88,7 @@ class CanPI(object):
             self.bus.send(msg)
 
         except Exception:
-            self.hpsu.printd('exception', 'Error sending msg')
+            self.hpsu.logger.exception('Error sending msg')
 
         if setValue:
             return "OK"
@@ -101,7 +101,7 @@ class CanPI(object):
                 rcBUS = self.bus.recv(timeout)
                 
             except Exception:
-                self.hpsu.printd('exception', 'Error recv')
+                self.hpsu.logger.exception('Error recv')
 
             if rcBUS:
                 if (msg_data[2] == 0xfa and msg_data[3] == rcBUS.data[3] and msg_data[4] == rcBUS.data[4]) or (msg_data[2] != 0xfa and msg_data[2] == rcBUS.data[2]):
@@ -109,15 +109,15 @@ class CanPI(object):
                     notTimeout = False
                     #print("got:  " + str(rc))
                 else:
-                    self.hpsu.printd('error', 'SEND:%s' % (str(msg_data)))
-                    self.hpsu.printd('error', 'RECV:%s' % (str(rcBUS.data)))
+                    self.hpsu.logger.error('SEND:%s' % (str(msg_data)))
+                    self.hpsu.logger.error('RECV:%s' % (str(rcBUS.data)))
             else:
-                self.hpsu.printd('error', 'Not aquired bus')
+                self.hpsu.logger.error('Not aquired bus')
 
             if notTimeout:
-                self.hpsu.printd('warning', 'msg not sync, retry: %s' % i)
+                self.hpsu.logger.warning('msg not sync, retry: %s' % i)
                 if i >= self.retry:
-                    self.hpsu.printd('error', 'msg not sync, timeout')
+                    self.hpsu.logger.error('msg not sync, timeout')
                     notTimeout = False
                     rc = "KO"
         

--- a/HPSU/plugins/emoncms.py
+++ b/HPSU/plugins/emoncms.py
@@ -64,14 +64,14 @@ class export():
                             if c == j["name"]:
                                 InCommand = False
                         if InCommand:
-                            self.hpsu.printd("warning", "command %s defined in emoncms but not as commandline option" % c)
+                            self.hpsu.logger.warning("command %s defined in emoncms but not as commandline option" % c)
 
                 except:
                     self.listNodes[option] = None
         
         for r in self.hpsu.commands:
             if r["name"] not in self.listCmd:
-                self.hpsu.printd("warning", "command %s defined as commandline option but not in emoncms" % r["name"])
+                self.hpsu.logger.warning("command %s defined as commandline option but not in emoncms" % r["name"])
 
     def pushValues(self, vars):
         #if self.plugin == "EMONCMS":
@@ -103,11 +103,11 @@ class export():
                     rc = r.text
                 except (requests.exceptions.Timeout):
                     rc = "ko"
-                    self.hpsu.printd("exception", "Connection timeout during get %s" % _urlNoApi)
+                    self.hpsu.logger.exception("Connection timeout during get %s" % _urlNoApi)
                 except (requests.exceptions.ConnectionError):
-                    self.hpsu.printd("exception", "Failed to establish a new connection to %s" % _urlNoApi)
+                    self.hpsu.logger.exception("Failed to establish a new connection to %s" % _urlNoApi)
                 except Exception:
                     rc = "ko"
-                    self.hpsu.printd("exception", "Exception on get %s" % _urlNoApi)
+                    self.hpsu.logger.exception("Exception on get %s" % _urlNoApi)
                     
         return True

--- a/HPSU/plugins/homematic.py
+++ b/HPSU/plugins/homematic.py
@@ -53,7 +53,7 @@ class export():
             urllib.request.urlopen(req)
         except urllib.error.URLError as e:
             rc = "ko"
-            self.hpsu.printd("exception", "Error " + str(e.code) + ": " + str(e.reason))
+            self.hpsu.logger.exception("Error " + str(e.code) + ": " + str(e.reason))
 
     def pushValues(self, vars=None):
         if self.method == "xmlapi":

--- a/HPSU/plugins/influxdb.py
+++ b/HPSU/plugins/influxdb.py
@@ -65,7 +65,7 @@ class export():
                
         except:
             rc = "ko"
-            self.hpsu.printd("exception", "Error : Cannot connect to database")
+            self.hpsu.logger.exception("Error : Cannot connect to database")
 
 
         self.client.switch_database(self.influxdbname)

--- a/HPSU/plugins/mqtt.py
+++ b/HPSU/plugins/mqtt.py
@@ -55,7 +55,7 @@ class export():
             self.username = self.config['MQTT']['USERNAME']
         else:
             self.username = None
-            print("Username not set!!!!!")
+            self.hpsu.logger.error("Username not set!!!!!")
 
         #MQTT Password
         if self.config.has_option('MQTT', "PASSWORD"):
@@ -84,7 +84,7 @@ class export():
     
         
     #def on_publish(self,client,userdata,mid):
-    #   print("data published, mid: " + str(mid) + "\n")
+    #   self.hpsu.logger.debug("data published, mid: " + str(mid) + "\n")
     #    pass
 
 

--- a/HPSU/plugins/mysql.py
+++ b/HPSU/plugins/mysql.py
@@ -49,19 +49,19 @@ class db():
         if db_config.has_option('MYSQL','DB_NAME'):
             db_name=db_config['MYSQL']['DB_NAME'] 
         else:
-            print("No database name defined in config file .")
+            self.hpsu.logger.error("No database name defined in config file .")
             sys.exit(9)
 
         if db_config.has_option('MYSQL','DB_USER'):
             db_user=db_config['MYSQL']['DB_USER']
         else: 
-            print("No database user defined in config file.")
+            self.hpsu.logger.error(("No database user defined in config file.")
             sys.exit(9)
 
         if db_config.has_option('MYSQL','DB_PASSWORD'):
             db_password=db_config['MYSQL']['DB_PASSWORD']
         else:
-            print("No password for the database user defined in config file")
+            self.hpsu.logger.error("No password for the database user defined in config file")
             sys.exit(9)
         
         self.db_params={ 'host':db_host, 'port':db_port, 'user':db_user, 'password':db_password, 'database':db_name } 
@@ -70,14 +70,14 @@ class db():
             self.db_conn= mysql.connector.connect(**self.db_params)
         except mysql.connector.Error as err:
             if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-                print("Username or password wrong")
+                self.hpsu.logger.error("Username or password wrong")
                 sys.exit(9)
             elif err.errno == errorcode.ER_BAD_DB_ERROR:
-                print("Database does not exist")
+                self.hpsu.logger.error("Database does not exist")
                 sys.exit(9)
         else:
             self.db_conn.close()
-            #print("Closed")
+            #self.hpsu.logger.debug("Closed")
         self.check_commands_db()
 
     def check_commands_db(self):

--- a/HPSU/plugins/openhab.py
+++ b/HPSU/plugins/openhab.py
@@ -51,7 +51,7 @@ class export():
             r = requests.put(url, data=str(value))
         except requests.exceptions.RequestException as e:
             rc = "ko"
-            self.hpsu.printd("exception", "Error " + str(e.code) + ": " + str(e.reason))
+            self.hpsu.logger.exception("Error " + str(e.code) + ": " + str(e.reason))
 
     def pushValues(self, vars=None):
         for r in vars:

--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -46,6 +46,10 @@ def main(argv):
     LOG_LEVEL_STRING = 'DEBUG, INFO, WARNING, ERROR, CRITICAL'
     # default to loggin.error if --log_level option not present
     desired_log_level = logging.ERROR
+    # default log to stdout if no file specified
+    log_handler = logging.StreamHandler()
+    # default log formatter
+    log_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     #commands = []
     #listCommands = []
     global config
@@ -75,7 +79,7 @@ def main(argv):
     except getopt.GetoptError:
         print('pyHPSU.py -d DRIVER -c COMMAND')
         print(' ')
-        print('           -a  --auto            do atomatic queries')
+        print('           -a  --auto            do automatic queries')
         print('           -f  --config          Configfile, overrides given commandline arguments')
         print('           -d  --driver          driver name: [ELM327, PYCAN, EMU, HPSUD], Default: PYCAN')
         print('           -p  --port            port (eg COM or /dev/tty*, only for ELM327 driver)')
@@ -139,11 +143,9 @@ def main(argv):
             options_list["language"]=arg.upper()
 
         elif opt in ("-g", "--log"):
-            logger = logging.getLogger('pyhpsu')
-            hdlr = logging.FileHandler(arg)
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-            hdlr.setFormatter(formatter)
-            logger.addHandler(hdlr)
+            log_handler = logging.FileHandler(arg)
+            options_list["log_file"]=arg
+
         elif opt in ("--log_level"):
             if arg == 'DEBUG':
                 desired_log_level = logging.DEBUG
@@ -159,9 +161,15 @@ def main(argv):
                 print("Error, " + arg + " is not a valid value for log_level option, use [" + LOG_LEVEL_STRING + "]")
                 sys.exit(2)
         options_list["cmd"]=cmd
+        
+    # if no log file has been specified and driver is HPSUD then log nothing
+    if options_list.get("log_file") is None and driver == "HPSUD":
+        log_handler = logging.NullHandler
 
-    if logger is not None:    
-        logger.setLevel(desired_log_level)
+    logger = logging.getLogger('pyhpsu')
+    log_handler.setFormatter(log_formatter)
+    logger.addHandler(log_handler)
+    logger.setLevel(desired_log_level)
 
     if verbose == "2":
         locale.setlocale(locale.LC_ALL, '')
@@ -174,14 +182,14 @@ def main(argv):
     # get config from file if given....
     if read_from_conf_file:
         if conf_file==None:
-            print("Error, please provide a config file")
+            logger.error("please provide a config file")
             sys.exit(9)
         else:
             try:
                 with open(conf_file) as f:
                     config.read_file(f)
             except IOError:
-                print("Error: config file not found")
+                logger.error("config file not found")
                 sys.exit(9)
         config.read(conf_file)
         if driver=="" and config.has_option('PYHPSU','PYHPSU_DEVICE'):
@@ -201,21 +209,21 @@ def main(argv):
     #
     # Check driver
     if driver not in ["ELM327", "PYCAN", "EMU", "HPSUD"]:
-        print("Error, please specify a correct driver [ELM327, PYCAN, EMU, HPSUD] ")
+        logger.error("please specify a correct driver [ELM327, PYCAN, EMU, HPSUD] ")
         sys.exit(9)
 
     if driver == "ELM327" and port == "":
-        print("Error, please specify a correct port for the ELM327 device ")
+        logger.error("please specify a correct port for the ELM327 device ")
         sys.exit(9)
 
     # Check output type
     if output_type not in PLUGIN_LIST:
-        print("Error, please specify a correct output_type [" + PLUGIN_STRING + "]")
+        logger.error("please specify a correct output_type [" + PLUGIN_STRING + "]")
         sys.exit(9)
 
     # Check Language
     if lg_code not in languages:
-        print("Error, please specify a correct language [%s]" % " ".join(languages))
+        logger.error("please specify a correct language [%s]" % " ".join(languages))
         sys.exit(9)
     # ------------------------------------
     # try to query different commands in different periods
@@ -233,7 +241,7 @@ def main(argv):
                     timed_jobs["timer_" + job_period].append(each_key)  # and add the value to this period
                 wanted_periods=list(timed_jobs.keys())
             else:
-                print("Error, please specify a value to query in config file ")
+                logger.error("please specify a value to query in config file ")
                 sys.exit(9)
 
     #
@@ -249,7 +257,9 @@ def main(argv):
                 try:
                     print("%20s - %-10s" % (n_hpsu.command_dict[cmd]['name'], (n_hpsu.command_dict[cmd]['label']) + ('' if n_hpsu.command_dict[cmd]['writable']=='true' else ' (readonly)')))
                 except KeyError:
-                    print("""!!!!!! No translation for "%12s" !!!!!!!""" % (n_hpsu.command_dict[cmd]['name']))
+                    error_message = """!!!!!! No translation for "%12s" !!!!!!!""" % (n_hpsu.command_dict[cmd]['name'])
+                    print(error_message)
+                    logger.error(error_message)
         else:
             print("%12s - %-10s - %s" % ('COMMAND', 'LABEL', 'DESCRIPTION'))
             print("%12s---%-10s---%s" % ('------------', '----------', '---------------------------------------------------'))
@@ -288,7 +298,7 @@ def main(argv):
                 n_hpsu = HPSU(driver=driver, logger=logger, port=port, cmd=restore_commands, lg_code=lg_code)
                 read_can(driver, logger, port, restore_commands, lg_code,verbose,output_type)
         except FileNotFoundError:
-            print("No such file or directory!!!")
+            logger.error("No such file or directory!!!")
             sys.exit(1)
 
     else:
@@ -312,7 +322,7 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
                     if not c["type"] == "value":
                         setValue = float(setValue)*float(c["divisor"])
                     else:
-                        n_hpsu.printd('error', 'type "value" not implemented since yet')
+                        logger.error('type "value" not implemented since yet')
                         return
 
             i = 0
@@ -328,9 +338,9 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
                 else:
                     i += 1
                     time.sleep(2.0)
-                    n_hpsu.printd('warning', 'retry %s command %s' % (i, c["name"]))
+                    logger.warning('retry %s command %s' % (i, c["name"]))
                     if i == 4:
-                        n_hpsu.printd('error', 'command %s failed' % (c["name"]))
+                        logger.error('command %s failed' % (c["name"]))
 
     if output_type == "JSON":
         if len(arrResponse)!=0:
@@ -339,12 +349,17 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
         for r in arrResponse:
             print("%s,%s,%s" % (r["timestamp"], r["name"], r["resp"]))
     elif output_type == "BACKUP":
-        print("Writing Backup to " + str(backup_file))
+        error_message = "Writing Backup to " + str(backup_file)
+        print(error_message)
+        logger.info(error_message)
+        
         try:
             with open(backup_file, 'w') as outfile:
                 json.dump(arrResponse, outfile, sort_keys = True, indent = 4, ensure_ascii = False)
         except FileNotFoundError:
-            print("No such file or directory!!!")
+            error_message = "No such file or directory!!!"
+            print(error_message)
+            logger.error(error_message)
             sys.exit(1)
     else:
         module_name=output_type.lower()

--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -247,14 +247,14 @@ def main(argv):
             print("%20s---%-10s" % ('------------', '----------'))
             for cmd in sorted(n_hpsu.command_dict) :
                 try:
-                    print("%20s - %-10s" % (n_hpsu.command_dict[cmd]['name'], n_hpsu.command_dict[cmd]['label']))
+                    print("%20s - %-10s" % (n_hpsu.command_dict[cmd]['name'], (n_hpsu.command_dict[cmd]['label']) + ('' if n_hpsu.command_dict[cmd]['writable']=='true' else ' (readonly)')))
                 except KeyError:
                     print("""!!!!!! No translation for "%12s" !!!!!!!""" % (n_hpsu.command_dict[cmd]['name']))
         else:
             print("%12s - %-10s - %s" % ('COMMAND', 'LABEL', 'DESCRIPTION'))
             print("%12s---%-10s---%s" % ('------------', '----------', '---------------------------------------------------'))
             for c in n_hpsu.commands:
-                print("%12s - %-10s - %s" % (c['name'], c['label'], c['desc']))
+                print("%12s - %-10s - %s" % (c['name'], c['label'] + ('' if c['writable']=='true' else ' (readonly)'), c['desc']))
         sys.exit(0)
 
         #

--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -43,6 +43,9 @@ def main(argv):
     ticker=0
     loop=True
     auto=False
+    LOG_LEVEL_STRING = 'DEBUG, INFO, WARNING, ERROR, CRITICAL'
+    # default to loggin.error if --log_level option not present
+    desired_log_level = logging.ERROR
     #commands = []
     #listCommands = []
     global config
@@ -68,7 +71,7 @@ def main(argv):
             PLUGIN_LIST.append(PLUGIN)
 
     try:
-        opts, args = getopt.getopt(argv,"ahc:p:d:v:o:l:g:f:b:r:", ["help", "cmd=", "port=", "driver=", "verbose=", "output_type=", "upload=", "language=", "log=", "config_file="])
+        opts, args = getopt.getopt(argv,"ahc:p:d:v:o:l:g:f:b:r:", ["help", "cmd=", "port=", "driver=", "verbose=", "output_type=", "upload=", "language=", "log=", "log_level=", "config_file="])
     except getopt.GetoptError:
         print('pyHPSU.py -d DRIVER -c COMMAND')
         print(' ')
@@ -82,7 +85,8 @@ def main(argv):
         print('           -l  --language        set the language to use [%s], default is \"EN\" ' % " ".join(languages))
         print('           -b  --backup          backup configurable settings to file [filename]')
         print('           -r  --restore         restore HPSU settings from file [filename]')
-        print('           -g  --log             set the log to file [_filename]')
+        print('           -g  --log             set the log to file [filename]')
+        print('           --log_level           set the log level to [' + LOG_LEVEL_STRING + ']')
         print('           -h  --help            show help')
         sys.exit(2)
 
@@ -140,8 +144,25 @@ def main(argv):
             formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
             hdlr.setFormatter(formatter)
             logger.addHandler(hdlr)
-            logger.setLevel(logging.ERROR)
+        elif opt in ("--log_level"):
+            if arg == 'DEBUG':
+                desired_log_level = logging.DEBUG
+            elif arg == 'INFO':
+                desired_log_level = logging.INFO
+            elif arg == 'WARNING':
+                desired_log_level = logging.WARNING
+            elif arg == 'ERROR':
+                desired_log_level = logging.ERROR
+            elif arg == 'CRITICAL':
+                desired_log_level = logging.CRITICAL
+            else:
+                print("Error, " + arg + " is not a valid value for log_level option, use [" + LOG_LEVEL_STRING + "]")
+                sys.exit(2)
         options_list["cmd"]=cmd
+
+    if logger is not None:    
+        logger.setLevel(desired_log_level)
+
     if verbose == "2":
         locale.setlocale(locale.LC_ALL, '')
 


### PR DESCRIPTION
Closes #37 

**NOTE: this pull request is about log, so it spreads over most of the python files, I am not able to test everything (e.g. openhub driver, HPSUD mode) so more peer inspection or peer test is needed**

This pull request removes the printd() method

```
    def printd(self, level, msg):        
        if self.logger:
            if level == 'warning':
                self.logger.warning(msg)
            elif level == 'error':
                self.logger.error(msg)
            elif level == 'info':
                self.logger.info(msg)
            elif level == 'exception':
                self.logger.exception(msg)
        else:
            if self.driver != "HPSUD":
                print("%s - %s" % (level, msg))

```

as it can be seen it has different problems:
- level is passed as string
- stardard logging levels, e.g. DEBUG, are missing
- if using a logger the logging level is respected, if not everything is printed to stdout discouraging developers to use debug, info and warning ...moreover in this only case the format is different
- "HPSUD mode" is without log and this is obtained accessing an "external object"

To obtain printd() flexibility, a single logger is instructed to use:
- `FileHandler` when -g option requires to save log to file
- `StreamHandler` for default behavious when log is written to stdout
- `NullHandler` when no log has to be written due to "HPSUD mode"

This "one-only-logger" approach enable all the log to use the same global settings for LOG LEVEL.

Having an effetive LOG LEVEL enables to change it via cli option, the `--log_level` has been introduced for this.

A single unique formatter is defined in advance.

Two info log line were added as proof of concept, they are one for loading of command definitions JSON file and the other for loading of command trasnlations CSV file.

Default level has been left as-is: ERROR.


In addition to log revision this pull request includes:
- little cosmetic fix, like typos
- a "help" improvement, now along each "_non-writable_" command description a "` (readonly)`" suffix is attached ...and this is because there are long more writable command than there are readonly command

Many things can be further improved, for instance:
- starting to log before and during options parsing
- introducing a method to write a message to stdout and log at the same time
- enabling logformatter to be read from conf file of cli option
- wrapping all the residual print("some message") to allow more control and avoid to mix them with real output (e.g. JSON)