### PR TITLE
one_hot_water works

### DIFF
--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -1417,7 +1417,7 @@
 			"divisor" : "1", 
 			"writable" : "true", 
 			"unit" : "longint",
-			"type" : "value",
+			"type" : "longint",
 			"value_code" : {
 				"0" : "off",
 				"1" : "on"


### PR DESCRIPTION
one_hot_water works with longint for a HPSU Compact 516 Biv (year 2017)

Closes one_hot_water not implemented? #43
