### PR TITLE
Correct V_VAR to float

### DIFF
--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -842,8 +842,8 @@
 			"id" : "190", 
 			"divisor" : "10", 
 			"writable" : "false", 
-			"unit" : "lh",
-			"type" : "longint"
+			"unit" : "",
+			"type" : "float"
 		},
 		"t_flow_ch_adj" : { 
 			"name" : "t_flow_ch_adj", 


### PR DESCRIPTION
V_VAR is actually a float value (liter/minute) and not an integer