### PR TITLE
Wrong divisor for T_FROST_PROTECT

### DIFF
--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -916,7 +916,7 @@
 			"name" : "t_frost_protect", 
 			"command" : "61 00 FA 0A 00 00 00", 
 			"id" : "190", 
-			"divisor" : "1", 
+			"divisor" : "10", 
 			"writable" : "true", 
 			"unit" : "deg",
 			"type" : "longint"

--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -919,7 +919,7 @@
 			"divisor" : "10", 
 			"writable" : "true", 
 			"unit" : "deg",
-			"type" : "longint"
+			"type" : "float"
 		},
 		"insulation" : { 
 			"name" : "insulation", 


### PR DESCRIPTION
The values for the temperature of frost protection were wrong, e.g. -50.0°C instead of -5.0°C