### PR TITLE
Fix command „error“

### DIFF
--- a/etc/pyHPSU/commands_hpsu.json
+++ b/etc/pyHPSU/commands_hpsu.json
@@ -491,7 +491,7 @@
 			"divisor" : "1", 
 			"writable" : "false", 
 			"unit" : "",
-			"type" : "value"
+			"type" : "longint"
 		},
 		"outdoor_type" : { 
 			"name" : "outdoor_type", 


### PR DESCRIPTION
As discussed in https://github.com/Spanni26/pyHPSU/issues/62 it was not possible to get correct values for the command „error“.

When adjusting the type to longint it works as expected