### PR TITLE
Changed output to valid json

### DIFF
--- a/pyHPSU.py
+++ b/pyHPSU.py
@@ -315,6 +315,7 @@ def read_can(driver,logger,port,cmd,lg_code,verbose,output_type):
 
     if output_type == "JSON":
         if len(arrResponse)!=0:
+            arrResponse = json.dumps(arrResponse)
             print(arrResponse)
     elif output_type == "CSV":
         for r in arrResponse:


### PR DESCRIPTION
The default Output is not valid json.
It´s a dict in a list.:
 [{'name': 't_hs', 'resp': '32.00', 'timestamp': 1544534667.414178}]

Added  arrResponse = json.dumps(arrResponse) to render a valid json format:
 [{"name": "t_dhw", "resp": "39.40", "timestamp": 1702020617.676643}]
